### PR TITLE
FX-8: exchange rate scheduler

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:7.2
+    image: redis:7-alpine
     container_name: local-redis
     ports:
       - "6379:6379"
@@ -10,5 +10,16 @@ services:
       - redis-data:/data
     command: [ "redis-server", "--save", "60", "1", "--loglevel", "warning" ]
 
+  redis-insight:
+    image: redislabs/redisinsight:latest
+    container_name: redis-insight
+    ports:
+      - "5540:5540"
+    depends_on:
+      - redis
+    volumes:
+      - redisinsight_data:/data
+
 volumes:
   redis-data:
+  redisinsight_data:

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -54,12 +54,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-docker-compose</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>
@@ -78,6 +72,18 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <version>4.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.20.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>1.20.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/generator/src/main/java/com/exchange/generator/GeneratorApplication.java
+++ b/generator/src/main/java/com/exchange/generator/GeneratorApplication.java
@@ -2,7 +2,9 @@ package com.exchange.generator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class GeneratorApplication {
 

--- a/generator/src/main/java/com/exchange/generator/publisher/ExchangeRatePublisher.java
+++ b/generator/src/main/java/com/exchange/generator/publisher/ExchangeRatePublisher.java
@@ -22,7 +22,6 @@ public class ExchangeRatePublisher {
     return redisTemplate
         .opsForHash()
         .putAll(key, map)
-        .doOnSuccess((success) -> LOGGER.info("Map published to Redis"))
         .doOnError((error) -> LOGGER.error("Error publishing to Redis: {}", error.getMessage()))
         .onErrorReturn(false);
   }

--- a/generator/src/main/java/com/exchange/generator/scheduler/ExchangeRateScheduler.java
+++ b/generator/src/main/java/com/exchange/generator/scheduler/ExchangeRateScheduler.java
@@ -1,0 +1,52 @@
+package com.exchange.generator.scheduler;
+
+import com.exchange.generator.publisher.ExchangeRatePublisher;
+import com.exchange.generator.service.CurrencyLayerService;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Component
+public class ExchangeRateScheduler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExchangeRateScheduler.class);
+  private static final String EXCHANGE_RATE_KEY = "exchangeRate";
+
+  private final CurrencyLayerService currencyLayerService;
+  private final ExchangeRatePublisher exchangeRatePublisher;
+
+  public ExchangeRateScheduler(
+      CurrencyLayerService currencyLayerService, ExchangeRatePublisher exchangeRatePublisher) {
+    this.currencyLayerService = currencyLayerService;
+    this.exchangeRatePublisher = exchangeRatePublisher;
+  }
+
+  @Scheduled(fixedRate = 60000)
+  public void scheduledRateUpdate() {
+    fetchAndPublishRates().subscribeOn(Schedulers.boundedElastic()).subscribe();
+  }
+
+  public Mono<Boolean> fetchAndPublishRates() {
+    return currencyLayerService
+        .getExchangeRate()
+        .flatMap(
+            response -> {
+              if (response.success()) {
+                return exchangeRatePublisher.publishExchangeRates(
+                    EXCHANGE_RATE_KEY, transformQuotes(response.quotes()));
+              }
+              LOGGER.error("Failed to fetch exchange rates");
+              return Mono.empty();
+            });
+  }
+
+  private Map<String, Double> transformQuotes(Map<String, Double> quotes) {
+    return quotes.entrySet().stream()
+        .collect(Collectors.toMap(entry -> entry.getKey().substring(3), Map.Entry::getValue));
+  }
+}

--- a/generator/src/main/java/com/exchange/generator/service/CurrencyLayerService.java
+++ b/generator/src/main/java/com/exchange/generator/service/CurrencyLayerService.java
@@ -2,12 +2,18 @@ package com.exchange.generator.service;
 
 import com.exchange.generator.model.CurrencyCode;
 import com.exchange.generator.model.ExchangeRateResponse;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 @Component
 public class CurrencyLayerService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CurrencyLayerService.class);
 
   private final WebClient currencyLayerWebClient;
 
@@ -20,6 +26,14 @@ public class CurrencyLayerService {
         .get()
         .uri(uriBuilder -> uriBuilder.path("/live").queryParam("source", CurrencyCode.USD).build())
         .retrieve()
-        .bodyToMono(ExchangeRateResponse.class);
+        .bodyToMono(ExchangeRateResponse.class)
+        .retryWhen(
+            Retry.backoff(3, Duration.ofSeconds(2))
+                .doBeforeRetry(
+                    signal ->
+                        LOGGER.warn(
+                            "Retrying CurrencyLayer API call: attempt {}",
+                            signal.totalRetries() + 1)))
+        .doOnError(error -> LOGGER.error("CurrencyLayer API is unavailable", error));
   }
 }

--- a/generator/src/test/java/com/exchange/generator/publisher/ExchangeRatePublisherIntegrationTest.java
+++ b/generator/src/test/java/com/exchange/generator/publisher/ExchangeRatePublisherIntegrationTest.java
@@ -6,20 +6,36 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.test.StepVerifier;
 
 @Tag("integration")
 @SpringBootTest
+@Testcontainers
 class ExchangeRatePublisherIntegrationTest {
+
+  @Container
+  static GenericContainer<?> redisContainer =
+      new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
 
   @Autowired private ExchangeRatePublisher publisher;
 
   @Autowired private ReactiveRedisTemplate<String, Double> redisTemplate;
 
+  @DynamicPropertySource
+  static void redisProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.redis.host", redisContainer::getHost);
+    registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+  }
+
   @Test
   void publishExchangeRates_shouldPersistInRedis() {
     String key = "exchange_rates";
-    Map<String, Double> rates = Map.of("EUR", 0.92, "GBP", 0.79);
+    Map<String, Double> rates = Map.of("EUR", 0.92, "GBP", 0.47);
 
     StepVerifier.create(
             publisher

--- a/generator/src/test/java/com/exchange/generator/scheduler/ExchangeRateSchedulerTest.java
+++ b/generator/src/test/java/com/exchange/generator/scheduler/ExchangeRateSchedulerTest.java
@@ -1,0 +1,51 @@
+package com.exchange.generator.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+
+import com.exchange.generator.model.ExchangeRateResponse;
+import com.exchange.generator.publisher.ExchangeRatePublisher;
+import com.exchange.generator.service.CurrencyLayerService;
+import java.util.Map;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class ExchangeRateSchedulerTest {
+
+  private CurrencyLayerService currencyLayerService;
+  private ExchangeRatePublisher exchangeRatePublisher;
+  private ExchangeRateScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    currencyLayerService = Mockito.mock(CurrencyLayerService.class);
+    exchangeRatePublisher = Mockito.mock(ExchangeRatePublisher.class);
+
+    scheduler = new ExchangeRateScheduler(currencyLayerService, exchangeRatePublisher);
+  }
+
+  @Test
+  void fetchAndPublishRates_shouldPublishTransformedRates() {
+    Map<String, Double> inputRates = Map.of("USDEUR", 0.92, "USDGBP", 0.79);
+    Map<String, Double> expectedRates = Map.of("EUR", 0.92, "GBP", 0.79);
+
+    Mockito.when(currencyLayerService.getExchangeRate())
+        .thenReturn(Mono.just(new ExchangeRateResponse(true, inputRates)));
+    Mockito.when(exchangeRatePublisher.publishExchangeRates("exchangeRate", expectedRates))
+        .thenReturn(Mono.just(true));
+
+    StepVerifier.create(scheduler.fetchAndPublishRates()).expectNext(true).verifyComplete();
+  }
+
+  @Test
+  void fetchAndPublishRates_shouldHandleApiFailure() {
+    Mockito.when(currencyLayerService.getExchangeRate())
+        .thenReturn(Mono.just(new ExchangeRateResponse(false, Map.of())));
+
+    StepVerifier.create(scheduler.fetchAndPublishRates()).verifyComplete();
+
+    Mockito.verify(exchangeRatePublisher, never()).publishExchangeRates(any(), any());
+  }
+}

--- a/generator/src/test/java/com/exchange/generator/service/CurrencyLayerServiceTest.java
+++ b/generator/src/test/java/com/exchange/generator/service/CurrencyLayerServiceTest.java
@@ -69,10 +69,14 @@ class CurrencyLayerServiceTest {
     Mockito.when(responseSpec.bodyToMono(ExchangeRateResponse.class))
         .thenReturn(Mono.error(expectedError));
 
-    Mono<ExchangeRateResponse> result = currencyLayerService.getExchangeRate();
-
-    StepVerifier.create(result)
-        .expectErrorMatches(throwable -> throwable.equals(expectedError))
+    StepVerifier.create(currencyLayerService.getExchangeRate())
+        .expectErrorMatches(
+            throwable -> {
+              Assertions.assertEquals("API error", throwable.getCause().getMessage());
+              return true;
+            })
         .verify();
+
+    Mockito.verify(responseSpec, Mockito.times(1)).bodyToMono(ExchangeRateResponse.class);
   }
 }


### PR DESCRIPTION
Redis insight image is also added to docker-compose file.

After local-redis:6379 connection is added, cache data can be monitored on localhost:5540.
Local redis insight information will be added Readme later on.

Scheduler is implemented to fetch and publish data in 1 minute interval

Test container plugin is also added to mock redis container on integration tests.

Closes #8 
